### PR TITLE
Adding rake task for syncing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ Effort has been taken to ensure that private information is excluded from the re
 
 ## Tasks
 
-  There is a rake task in lib/tasks/scheduler.rake available to use as a cron job.
+  There are rake tasks in lib/tasks/scheduler.rake available to use as a cron job.
 ```
   $ bundle exec rake update_pull_requests
+```
+```
+  $ bundle exec rake update_issues
 ```
   ## Contributing
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -23,7 +23,7 @@ class Issue < ApplicationRecord
     issues.each do |issue|
       begin
         updated_issue = octokit_service.get_issue(issue)
-        puts updated_issue.inspect
+
         issue.updates_issue(updated_issue)
       rescue Octokit::NotFound
         self.remove_closed_issue(issue)

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -16,6 +16,21 @@ class Issue < ApplicationRecord
     end
   end
 
+  def self.sync_with_github
+    issues = self.where(state: :open)
+    octokit_service = OctokitService.new(ENV["GITHUB_MACHINE_USER_ACCESS_TOKEN"])
+
+    issues.each do |issue|
+      begin
+        updated_issue = octokit_service.get_issue(issue)
+        puts updated_issue.inspect
+        issue.updates_issue(updated_issue)
+      rescue Octokit::NotFound
+        self.remove_closed_issue(issue)
+      end
+    end
+  end
+
   def issue_assignees(_assignees)
     self.assignees = []
 
@@ -25,9 +40,19 @@ class Issue < ApplicationRecord
     end
   end
 
+  def updates_issue(updated_issue)
+    update(state: updated_issue["state"])
+
+    issue_assignees(updated_issue["assignees"])
+  end
+
   def self.remove_closed_issues(_issues)
     github_issues_links = _issues.map {|x| x.html_url }
     Issue.where.not(issue_link: github_issues_links).delete_all
+  end
+
+  def self.remove_closed_issue(_issue)
+    Issue.find(_issue.id).delete
   end
 
   def repo_url(pr)

--- a/app/services/octokit_service.rb
+++ b/app/services/octokit_service.rb
@@ -15,6 +15,10 @@ class OctokitService
     end
   end
 
+  def get_issue(issue)
+   client.issue(issue.repository_name, issue.issue_number)
+  end
+
   def get_pull_requests(repositories)
     repositories.flatten.flat_map do |r|
       client.pull_requests(r.full_name, :state => 'open')

--- a/fixtures/vcr_cassettes/Issue_sync_with_github/deletes_issues_that_are_no_longer_open.yml
+++ b/fixtures/vcr_cassettes/Issue_sync_with_github/deletes_issues_that_are_no_longer_open.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/test/test/issues/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.18.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token $ACCESS_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 19 May 2020 15:20:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4966'
+      X-Ratelimit-Reset:
+      - '1589904109'
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - FE91:3DE9:7EF595:DA19AF:5EC3F920
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/issues/#get-a-single-issue"}'
+    http_version: null
+  recorded_at: Tue, 19 May 2020 15:20:00 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/Issue_sync_with_github/updates_issues_that_are_open.yml
+++ b/fixtures/vcr_cassettes/Issue_sync_with_github/updates_issues_that_are_open.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/TestDash/fake-repo/issues/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.18.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token $ACCESS_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 19 May 2020 15:20:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4965'
+      X-Ratelimit-Reset:
+      - '1589904109'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - W/"1eed7eecbe809fd6a53e034c20758af4"
+      Last-Modified:
+      - Mon, 18 May 2020 16:14:03 GMT
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - FE92:1276:224EA8:5D950C:5EC3F920
+    body:
+      encoding: ASCII-8BIT
+      string: '{"url":"https://api.github.com/repos/TestDash/fake-repo/issues/1","repository_url":"https://api.github.com/repos/TestDash/fake-repo","labels_url":"https://api.github.com/repos/TestDash/fake-repo/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/TestDash/fake-repo/issues/1/comments","events_url":"https://api.github.com/repos/TestDash/fake-repo/issues/1/events","html_url":"https://github.com/TestDash/fake-repo/issues/1","id":607749041,"node_id":"MDU6SXNzdWU2MDc3NDkwNDE=","number":1,"title":"Test
+        issue","user":{"login":"ombu-bot","id":64282342,"node_id":"MDQ6VXNlcjY0MjgyMzQy","avatar_url":"https://avatars1.githubusercontent.com/u/64282342?v=4","gravatar_id":"","url":"https://api.github.com/users/ombu-bot","html_url":"https://github.com/ombu-bot","followers_url":"https://api.github.com/users/ombu-bot/followers","following_url":"https://api.github.com/users/ombu-bot/following{/other_user}","gists_url":"https://api.github.com/users/ombu-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/ombu-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ombu-bot/subscriptions","organizations_url":"https://api.github.com/users/ombu-bot/orgs","repos_url":"https://api.github.com/users/ombu-bot/repos","events_url":"https://api.github.com/users/ombu-bot/events{/privacy}","received_events_url":"https://api.github.com/users/ombu-bot/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":{"login":"ombu-bot","id":64282342,"node_id":"MDQ6VXNlcjY0MjgyMzQy","avatar_url":"https://avatars1.githubusercontent.com/u/64282342?v=4","gravatar_id":"","url":"https://api.github.com/users/ombu-bot","html_url":"https://github.com/ombu-bot","followers_url":"https://api.github.com/users/ombu-bot/followers","following_url":"https://api.github.com/users/ombu-bot/following{/other_user}","gists_url":"https://api.github.com/users/ombu-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/ombu-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ombu-bot/subscriptions","organizations_url":"https://api.github.com/users/ombu-bot/orgs","repos_url":"https://api.github.com/users/ombu-bot/repos","events_url":"https://api.github.com/users/ombu-bot/events{/privacy}","received_events_url":"https://api.github.com/users/ombu-bot/received_events","type":"User","site_admin":false},"assignees":[{"login":"ombu-bot","id":64282342,"node_id":"MDQ6VXNlcjY0MjgyMzQy","avatar_url":"https://avatars1.githubusercontent.com/u/64282342?v=4","gravatar_id":"","url":"https://api.github.com/users/ombu-bot","html_url":"https://github.com/ombu-bot","followers_url":"https://api.github.com/users/ombu-bot/followers","following_url":"https://api.github.com/users/ombu-bot/following{/other_user}","gists_url":"https://api.github.com/users/ombu-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/ombu-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ombu-bot/subscriptions","organizations_url":"https://api.github.com/users/ombu-bot/orgs","repos_url":"https://api.github.com/users/ombu-bot/repos","events_url":"https://api.github.com/users/ombu-bot/events{/privacy}","received_events_url":"https://api.github.com/users/ombu-bot/received_events","type":"User","site_admin":false}],"milestone":null,"comments":0,"created_at":"2020-04-27T18:13:40Z","updated_at":"2020-05-18T14:40:59Z","closed_at":null,"author_association":"CONTRIBUTOR","body":"","closed_by":null}'
+    http_version: null
+  recorded_at: Tue, 19 May 2020 15:20:00 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/PullRequest_sync_with_github/deletes_all_open_pull_requests_that_aren_t_found.yml
+++ b/fixtures/vcr_cassettes/PullRequest_sync_with_github/deletes_all_open_pull_requests_that_aren_t_found.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/test/test/pulls/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.18.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - token $ACCESS_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 19 May 2020 15:17:33 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4967'
+      X-Ratelimit-Reset:
+      - '1589904109'
+      X-Oauth-Scopes:
+      - repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - FE8C:4D98:15CCC7:39F6A9:5EC3F88D
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/pulls/#get-a-single-pull-request"}'
+    http_version: null
+  recorded_at: Tue, 19 May 2020 15:17:33 GMT
+recorded_with: VCR 5.1.0

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -8,7 +8,6 @@ end
 desc "This task uses the github API to update issues"
 task :update_issues => :environment do
   puts "Updating issues..."
-  byebug
   Issue.sync_with_github
   puts "done."
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -4,3 +4,11 @@ task :update_pull_requests => :environment do
   PullRequest.sync_with_github
   puts "done."
 end
+
+desc "This task uses the github API to update issues"
+task :update_issues => :environment do
+  puts "Updating issues..."
+  byebug
+  Issue.sync_with_github
+  puts "done."
+end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     issue_number { "123" }
     issue_link { "http://test_issue" }
     repository_link { "http://repo_issue" }
-    state { "opened" }
+    state { "open" }
     repository_name { "test/test" }
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -12,13 +12,17 @@ RSpec.describe Issue do
       end
 
       it "updates issues that are open", :vcr do
-        user_bot = FactoryBot.create(:user,
-                                    name: "ombu-bot",
-                                    id: 1)
+        user_bot = FactoryBot.create(
+          :user,
+          name: "ombu-bot",
+          id: 1
+          )
 
-        open_issue = FactoryBot.create(:issue,
-                                      repository_name: "TestDash/fake-repo",
-                                      issue_number: "1")
+        open_issue = FactoryBot.create(
+          :issue,
+          repository_name: "TestDash/fake-repo",
+          issue_number: "1"
+          )
 
         Issue.sync_with_github
         expect(open_issue.assignees.count).to eq 1

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Issue do
+
+  describe '.sync_with_github' do
+
+
+      it "deletes issues that are no longer open", :vcr  do
+
+        issue = FactoryBot.create(:issue)
+
+        Issue.sync_with_github
+        expect(Issue.all).to be_empty
+      end
+
+      it "updates issues that are open", :vcr do
+        user_bot = FactoryBot.create(:user,
+                                    name: "ombu-bot",
+                                    id: 1)
+
+        open_issue = FactoryBot.create(:issue,
+                                      repository_name: "TestDash/fake-repo",
+                                      issue_number: "1")
+
+        Issue.sync_with_github
+        expect(open_issue.assignees.count).to eq 1
+      end
+  end
+end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Issue do
           :user,
           name: "ombu-bot",
           id: 1
-          )
+        )
 
         open_issue = FactoryBot.create(
           :issue,
           repository_name: "TestDash/fake-repo",
           issue_number: "1"
-          )
+        )
 
         Issue.sync_with_github
         expect(open_issue.assignees.count).to eq 1

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Issue do
 
   describe '.sync_with_github' do
 
-
       it "deletes issues that are no longer open", :vcr  do
-
         issue = FactoryBot.create(:issue)
 
         Issue.sync_with_github

--- a/spec/models/pivotal_story_spec.rb
+++ b/spec/models/pivotal_story_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe PivotalStory do
         story_link: "www.link.com",
         project_link: "www.link/project_id",
         story_number: 5
-        )
+      )
       user = FactoryBot.create(
         :user,
         pivotal_id: 4578
-        )
+      )
       pivotal_story =
         TrackerApi::Resources::Story.new(
           url: "www.linktest.com",
@@ -26,7 +26,7 @@ RSpec.describe PivotalStory do
           project_id: 78593,
           id: 5,
           owner_ids: [4578]
-          )
+        )
       PivotalStory.create_update_pivotal_story(pivotal_story, "The Project")
 
       story.reload

--- a/spec/models/pivotal_story_spec.rb
+++ b/spec/models/pivotal_story_spec.rb
@@ -6,14 +6,18 @@ RSpec.describe PivotalStory do
   describe '.create_update_pivotal_story' do
 
     it "updates the state of the stories" do
-      story = FactoryBot.create(:pivotal_story,
-                                state: "unstarted",
-                                name: "MyTest",
-                                story_link: "www.link.com",
-                                project_link: "www.link/project_id",
-                                story_number: 5)
-      user = FactoryBot.create(:user,
-                              pivotal_id: 4578)
+      story = FactoryBot.create(
+        :pivotal_story,
+        state: "unstarted",
+        name: "MyTest",
+        story_link: "www.link.com",
+        project_link: "www.link/project_id",
+        story_number: 5
+        )
+      user = FactoryBot.create(
+        :user,
+        pivotal_id: 4578
+        )
       pivotal_story =
         TrackerApi::Resources::Story.new(
           url: "www.linktest.com",
@@ -22,7 +26,7 @@ RSpec.describe PivotalStory do
           project_id: 78593,
           id: 5,
           owner_ids: [4578]
-        )
+          )
       PivotalStory.create_update_pivotal_story(pivotal_story, "The Project")
 
       story.reload

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -20,5 +20,13 @@ RSpec.describe PullRequest do
       expect(pr.state).to eq("open")
       expect(pr.assignees).to include(user_bot)
     end
+
+    it "deletes all open pull requests that aren't found", :vcr do
+      pull_request = FactoryBot.create(:pull_request)
+
+      PullRequest.sync_with_github
+
+      expect(PullRequest.all).to be_empty
+    end
   end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe PullRequest do
         pull_request_number: "2",
         title: "Pull Request Test",
         repository_name: "testdash/fake-repo"
-        )
+      )
       user_bot = FactoryBot.create(
         :user,
         name: "ombu-bot"
-        )
+      )
 
       PullRequest.sync_with_github
 

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -5,13 +5,18 @@ RSpec.describe PullRequest do
   describe '.sync_with_github' do
 
     it "syncs with github", :vcr do
-      pr = FactoryBot.create(:pull_request,
-                            pull_request_link: "https://github.com/testdash/fake-repo/pull/2",
-                            state: "open",
-                            pull_request_number: "2",
-                            title: "Pull Request Test",
-                            repository_name: "testdash/fake-repo")
-      user_bot = FactoryBot.create(:user, name: "ombu-bot")
+      pr = FactoryBot.create(
+        :pull_request,
+        pull_request_link: "https://github.com/testdash/fake-repo/pull/2",
+        state: "open",
+        pull_request_number: "2",
+        title: "Pull Request Test",
+        repository_name: "testdash/fake-repo"
+        )
+      user_bot = FactoryBot.create(
+        :user,
+        name: "ombu-bot"
+        )
 
       PullRequest.sync_with_github
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ VCR.configure do |config|
 
   config.filter_sensitive_data('$ACCESS_TOKEN') { ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] }
   config.filter_sensitive_data('$ACCESS_TOKEN') { ENV['PIVOTAL_TOKEN'] }
+  config.filter_sensitive_data('$ACCESS_TOKEN') { ENV['GITHUB_MACHINE_USER_ACCESS_TOKEN'] }
 end
 
 RSpec::Sidekiq.configure do |config|

--- a/spec/workers/pivotal_worker_spec.rb
+++ b/spec/workers/pivotal_worker_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe PivotalWorker, type: :worker do
         name: "ombu-bot",
         id: 3,
         pivotal_token: ENV["PIVOTAL_TOKEN"],
-        pivotal_id: nil)
+        pivotal_id: nil
+        )
 
       expect{
         PivotalWorker.new.perform(user_bot.id)

--- a/spec/workers/pivotal_worker_spec.rb
+++ b/spec/workers/pivotal_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PivotalWorker, type: :worker do
         id: 3,
         pivotal_token: ENV["PIVOTAL_TOKEN"],
         pivotal_id: nil
-        )
+      )
 
       expect{
         PivotalWorker.new.perform(user_bot.id)


### PR DESCRIPTION
This PR creates a rake task that allows the user to create a cron job to sync the github issues. It also adds specs for testing this behavior in the issue model and an extra spec for the pill_request model. 

https://github.com/fastruby/dash/issues/8