### PR TITLE
Add Feature Request template when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,47 @@
+---
+name: Feature request
+about: Request a new feature
+title: "[REQUEST]"
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+
+**Before we start...:**
+
+- [ ] I checked the documentation and didn't find this feature
+- [ ] I checked to make sure that this feature has not already been requested
+
+
+**Branch/Commit:**
+
+Inform what branch/commit/version of "Dash" you are using.
+
+**Describe the feature:**
+
+Please include a detailed description of the feature you are requesting and any detail on it’s expected behavior.
+
+> **As a \<role name\>**
+> **I do \<something\>**
+> **And then I do \<another action\>**
+> **And I see \<some result\>**
+ 
+**Problem:**
+
+Please include a detailed description of the problem this feature would solve.
+
+> **As a \<role name\>**
+> **I want to \<do something\>**
+> **So that I can achieve a \<goal\>**
+ 
+**Mockups:**
+
+Include any mockup idea related to the requested feature if it applies.
+ 
+**Resources:**
+
+If you have resources related to the implementation or research for this feature, add them here.
+ 
+**I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md)**


### PR DESCRIPTION
When creating an issue, we only have a template for Bug reports but not for Feature Requests. This PR adds a template for that and github will ask the author which template to use when creating a new issue.

https://www.pivotaltracker.com/story/show/175363270

https://docs.github.com/en/enterprise/2.14/user/articles/about-issue-and-pull-request-templates#issue-templates