### PR TITLE
Lower log level to prevent filling the heroku logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
We are receiving emails by heroku daily saying that logs are getting full and it stops logging information (probably because of the background jobs synchronizing de data). This is a problem because after some point of the day, if we have some error we lose any information related to it on the logs.

This PR changes the log_level from :debug to :error, so we don't log that much but keep logging errors.

I understand this PR wouldn't follow our normal PR process of using staging, since it needs to be deployed to production to know if it's actually working (we don't receive notifications from the staging app, it doesn't run the background jobs).