### PR TITLE
Change sidekiq's log level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,3 +111,7 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end
+
+Sidekiq.configure_server do |config|
+  config.logger.level = Logger::WARN
+end


### PR DESCRIPTION
On a previous PR I changed the log level of the rails app, looks like it's not enough and sidekiq uses it's own log level. On this PR I'm changing sidekiq's log level in production from INFO (the default) to WARN (to log warnings, and errors).

I checked the logs and they are flooded with queries done by the scheduler.

This PR also has to be merged in production to actually be tested, there's nothing to test in staging.

https://www.pivotaltracker.com/story/show/175363800