### PR TITLE
Use 'lockbox_encrypts' instead of 'encrypts'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   has_many :pivotal_stories, through: :pivotal_stories_owners
   has_many :owned_pull_requests, foreign_key: "author_id", class_name: "PullRequest"
 
-  encrypts :pivotal_token
+  lockbox_encrypts :pivotal_token
 
   validates :pivotal_token, length: { is: 32 },
                             allow_blank: true,


### PR DESCRIPTION
Description:

This PR fixes the use of the `lockbox` gem to play nicely with Rails 7, fixing both builds on CI.

They renamed the `encrypts` method to `lockbox_encrypts` here in version 0.6.4 https://github.com/ankane/lockbox/issues/107

Rails 7 added native encryption and it uses the same `encrypts` method and CI was failing because Rails 7 expects a different key in a different place than the one lockbox uses.

This fixes https://github.com/fastruby/dash/issues/105

I will abide by the [code of conduct](../blob/main/CODE_OF_CONDUCT.md).
