### PR TITLE
Improve CI speed by updating caching and setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
             - v1-dependencies-current-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-current-
+            - v1-dependencies-
 
       - run:
           name: install dependencies
@@ -103,6 +104,7 @@ jobs:
             - v1-dependencies-next-{{ checksum "Gemfile.next.lock" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-next-
+            - v1-dependencies-
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            npm install
             gem update bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
             bundle exec rake assets:precompile
@@ -110,7 +109,6 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            npm install
             gem update bundler
             export BUNDLE_GEMFILE=Gemfile.next
             bundle update rails --jobs=4 --retry=3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-current-{{ checksum "Gemfile.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-current
+            - v1-dependencies-current-
 
       - run:
           name: install dependencies
@@ -47,9 +47,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            - v1-dependencies-current
+          key: v1-dependencies-current-{{ checksum "Gemfile.lock" }}
 
       # Database setup
       - run: bundle exec rake db:create
@@ -102,9 +100,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "Gemfile.next.lock" }}
+            - v1-dependencies-next-{{ checksum "Gemfile.next.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-next
+            - v1-dependencies-next-
 
       - run:
           name: install dependencies
@@ -118,9 +116,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.next.lock" }}
-            - v1-dependencies-next
+          key: v1-dependencies-next-{{ checksum "Gemfile.next.lock" }}
 
       # Database setup
       - run: bundle exec rake db:create

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
+            - ./node_modules
           key: v1-dependencies-current-{{ checksum "Gemfile.lock" }}
 
       # Database setup
@@ -112,12 +113,13 @@ jobs:
             npm install
             gem update bundler
             export BUNDLE_GEMFILE=Gemfile.next
-            bundle update --jobs=4 --retry=3
+            bundle update rails --jobs=4 --retry=3
             bundle exec rake assets:precompile
 
       - save_cache:
           paths:
             - ./vendor/bundle
+            - ./node_modules
           key: v1-dependencies-next-{{ checksum "Gemfile.next.lock" }}
 
       # Database setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,23 +32,24 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-current
 
       - run:
           name: install dependencies
           command: |
             npm install
             gem update bundler
-            bundle update --bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
             bundle exec rake assets:precompile
 
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-current
 
       # Database setup
       - run: bundle exec rake db:create
@@ -101,16 +102,15 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.next.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "Gemfile.next.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-next
 
       - run:
           name: install dependencies
           command: |
             npm install
             gem update bundler
-            bundle update --bundler
             export BUNDLE_GEMFILE=Gemfile.next
             bundle update --jobs=4 --retry=3
             bundle exec rake assets:precompile
@@ -118,7 +118,9 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.next.lock" }}
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.next.lock" }}
+            - v1-dependencies-next
 
       # Database setup
       - run: bundle exec rake db:create


### PR DESCRIPTION
**Description:**

This PR adds some improvements for the caching configuration on CI and the setup so tests take less time to run.

We had to wait more than 6 minutes just so the tests run in 7 seconds.

I updated a few things:
- use different keys and fallback keys for the current and next rails versions
- don't run `npm install` manually, rails runs `yarn install` which is faster (doesn't fail to find the node-sass bindings)
- cached the node_modules folder too
- don't run `bundle update` for rails 6.1
- only update the rails gem (and its dependencies) for rails 7.x, not all gems

Now it takes 35s to setup the tests for 6.1:
![image](https://user-images.githubusercontent.com/188464/127010403-22a1db71-23d3-498e-80e7-5f6d3fd510e3.png)

And 3.5min for 7.x:
![image](https://user-images.githubusercontent.com/188464/127010493-68cbc65a-de65-47d3-ba98-b52c0020e09d.png)

(I can't improve much more here since it needs to install all the gems related to updating rails to the latest main commit, but it's a good gain compared to 6/7 minutes)

I will abide by the code of conduct.
