### PR TITLE
Add task to update pivotal stories for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,17 @@ Effort has been taken to ensure that private information is excluded from the re
 ## Tasks
 
   There are rake tasks in lib/tasks/scheduler.rake available to use as a cron job.
+
 ```
   $ bundle exec rake update_pull_requests
 ```
 ```
   $ bundle exec rake update_issues
 ```
+```
+  $ bundle exec rake update_pivotal_stories
+```
+
   ## Contributing
 
   Bug reports and pull requests are welcome on GitHub at [https://github.com/fastruby/dash](https://github.com/fastruby/dash). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/app/models/pivotal_story.rb
+++ b/app/models/pivotal_story.rb
@@ -31,4 +31,12 @@ private
   def self.project_url(project_id)
     "https://www.pivotaltracker.com/n/projects/#{project_id}"
   end
+
+  def self.sync_with_pivotal_tracker
+    users = User.all
+    users.each do |user|
+      next unless user.pivotal_token.present?
+      PivotalWorker.perform_async(user.id)
+    end
+  end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -11,3 +11,10 @@ task :update_issues => :environment do
   Issue.sync_with_github
   puts "done."
 end
+
+desc "This task uses the Pivotal Tracker API to update the stories"
+task :update_pivotal_stories => :environment do
+  puts "Updating pivotal stories..."
+  PivotalStory.sync_with_pivotal_tracker
+  puts "done."
+end


### PR DESCRIPTION
closes #3

Description:

Add a new task to update the pivotal tracker stories as same as we do for GitHub issues and pull requests
